### PR TITLE
Update repository to reference organizational Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,13 +1,12 @@
 # Contributor Code of Conduct
 
-The Creative Commons team is committed to fostering a welcoming community. This
-project and all other Creative Commons open source projects are governed by our
-[Code of Conduct][code_of_conduct]. Please report unacceptable behavior to
-[conduct@creativecommons.org](mailto:conduct@creativecommons.org) per our
-[reporting guidelines][reporting_guide].
+[`CODE_OF_CONDUCT.md`][org-coc]:
+> The Creative Commons team is committed to fostering a welcoming community.
+> This project and all other Creative Commons open-source projects are governed
+> by our [Code of Conduct][code_of_conduct]. Please report unacceptable
+> behavior to [conduct@creativecommons.org](mailto:conduct@creativecommons.org)
+> per our [reporting guidelines][reporting_guide].
 
-For a history of updates, see the [page history here][updates].
-
-[code_of_conduct]:https://creativecommons.github.io/community/code-of-conduct/
-[reporting_guide]:https://creativecommons.github.io/community/code-of-conduct/enforcement/
-[updates]:https://github.com/creativecommons/creativecommons.github.io-source/commits/master/content/community/code-of-conduct/contents.lr
+[org-coc]: https://github.com/creativecommons/.github/blob/main/CODE_OF_CONDUCT.md
+[code_of_conduct]: https://opensource.creativecommons.org/community/code-of-conduct/
+[reporting_guide]: https://opensource.creativecommons.org/community/code-of-conduct/enforcement/


### PR DESCRIPTION
Description
This commit updates the repository to ensure it references the Creative Commons organizational Code of Conduct.

Technical details
Updated the documentation to reference the official organizational Code of Conduct.
Tests
To verify that this PR fixes the problem, please review the README.md for the updated reference to the organizational Code of Conduct. Check that it links correctly and leads to the appropriate page.